### PR TITLE
Update 02_regions_definition.md

### DIFF
--- a/docs/02_regions_definition.md
+++ b/docs/02_regions_definition.md
@@ -15,6 +15,7 @@ First-order regions of the RGI version 7.0 and glacier locations in red. [Downlo
 
 First-order regions `10`, `19` and `20` straddle the 180th meridian, and so do the second-order regions `19-15` and `20-01`. For convenience of analysis in a cylindrical-equidistant coordinate system centered on longitude 0°, as in [Figure 1](global-fig), the region outlines of `10` and `19-15` appear in the accompanying shapefiles as two polygons, eastern and western. 
 
+**GTN-G regions**
 The region outlines have changed slightly between RGI versions, for example to avoid the splitting of glaciers between two regions, to make further analyses more convenient, or because previously not included glaciers were located outside existing region boundaries. For the sake of consistency between global glacier datasets a joint set of regions was recommended by the Global Terrestrial Network for Glaciers (GTN-G) Advisory Board, the Global Land Ice Measurements from Space initiative (GLIMS), the RGI Working Group of the International Association of Cryospheric Sciences (IACS), and the World Glacier Monitoring Service (WGMS). These glacier regions were implemented first in RGI version 6.0 and are available [on the GTN-G website](https://www.gtn-g.ch/data_catalogue_glacreg). These region boundaries were slightly modified in RGI version 7.0 and changes also integrated in the GTN-G data set (NEW REFERENCE)
 
 
@@ -23,18 +24,18 @@ The region outlines have changed slightly between RGI versions, for example to a
 **Region boundary and name changes:**
 
 - The region boxes for region `01` (Alaska) used to encompass some islands in the Bering Sea East of Kamtchatka. One of the two boxes, part of subregion `01-03` Alaska Peninsula (Aleutians), contains no glaciers (and probably hasn't for a long time) and is now removed.
-- Subregion `05-11` (Greenland Ice Sheet) has been removed since it was coarsely defined and the RGI does not include the ice sheet proper.
-- The southern boundary of region `12` (Caucasus and Middle East) has been shifted south by 2° (from 32°N to 30°N) to encompass a cluster of glaciers which were previously not included.
+- Subregion `05-11` (Greenland Ice Sheet) was removed since it was coarsely defined and the RGI does not include the ice sheet proper.
+- The southern boundary of region `12` (Caucasus and Middle East) was shifted south by 2° (from 32°N to 30°N) to encompass a cluster of glaciers which were previously not included.
 - Region `19` ("Antarctic and Subantarctic") was split into two first-order regions. Region `19` now solely includes the islands in the periphery of Antarctica, and was renamed to "Subantarctic and Antarctic Islands". A new region `20`, ("Antarctic Mainland") was added to encompass the remaining subregion ("Antarctic Ice Sheet", previously `19-31` and now `20-01`), but it presently contains no glaciers in the RGI (nor has the corresponding former subregion `19-31` in all previous RGI versions).
-- Region names in the region shapefiles (and therefore of the associated RGI product files) have been harmonized to reflect the most commonly used version in various documents and publications of the RGI. "Arctic Canada, North" and "Arctic Canada, South" have been renamed "Arctic Canada North" and "Arctic Canada South" (comma removed). The four regions in Asia ("North", "Central", "South West" and "South East") were renamed to "North Asia", "Central Asia", "South Asia West" and "South Asia East". With this change, none of the regions and subregions in RGI 7.0 have a comma in their name.
+- Region names in the region shapefiles (and therefore of the associated RGI product files) were harmonized to reflect the most commonly used version in various documents and publications of the RGI. "Arctic Canada, North" and "Arctic Canada, South" have been renamed "Arctic Canada North" and "Arctic Canada South" (comma removed), respectively. The four regions in Asia ("North", "Central", "South West" and "South East") were renamed to "North Asia", "Central Asia", "South Asia West" and "South Asia East", respectively. With this change, none of the regions and subregions in RGI 7.0 have a comma in their name.
 
 **Technical changes:**
 
 - The data type of the `rgi_code` attribute in the first-order region file is now `str` (instead of `int`). The `rgi_code` now has a leading zero, for example `02` instead of `2`.
 - All abbreviations in the second-order regions file have been replaced by their full name (e.g. "East Central" instead of "EC")
 - The first-order and second-order region files now have a field called `long_code` which contains a string representing the full region name, using the lowercase with underscores format (e.g. `02_western_canada_usa`). This field is used to name the corresponding RGI shapefiles.
-- The `WGMS_CODE` column has been deleted from all files.
-- The `RGI_CODE` column is now called `o1region` (first order files) and `o2region` (second-order files)
+- The `WGMS_CODE` column was deleted from all files.
+- The `RGI_CODE` column is now called `o1region` (first order files) and `o2region` (second-order files).
 
 
 ```{admonition} Additional details: RGI regions version history


### PR DESCRIPTION
1) make GTN-G more prominent by header small header while avoiding to call the entire section GTN-G regions which only is confusing and not appropriate. 

2) tried to streamline grammar, lots of mixing of tenses, in fact throughout the entire documents which is a but ugly (´have been´ vs ´were´). The meaning is different (´have been´ continuing to the present). In US English even then past is used. At least in the same paragraphs we should not switch back and forth. So, I adjusted here consistently.