### PR TITLE
Improve description of links tables

### DIFF
--- a/docs/products/glacier_product.md
+++ b/docs/products/glacier_product.md
@@ -30,20 +30,20 @@ In the following, file contents are explained using RGI region 01 (Alaska) as ex
 `RGI2000-v7.0-G-01_alaska-rgi6_links.csv`
 : A list of **all overlaps** (greater than 200 m<sup>2</sup>) between pairs of RGI 7.0 and RGI 6.0 glacier outlines, described by the following columns:
 
-```{card}
-| Column | Type | Description |
-| -- | -- | -- |
-| `rgi7_id` | `string` | RGI 6.0 outline |
-| `rgi6_id` | `string` | RGI 7.0 outline |
-| `overlap_area_km2` | `number` | Overlap area in km<sup>2</sup> |
-| `rgi7_area_fraction` | `number` | Overlap area (`overlap_area_km2`) divided by the area of the RGI 7.0 outline (`rgi7_id`) |
-| `rgi6_area_fraction` | `number` | Overlap area (`overlap_area_km2`) divided by the area of the RGI 60 outline (`rgi6_id`) |
-| `n_rgi7` | `integer` | Total number of RGI 7.0 outlines that overlap the RGI 6.0 outline (`rgi6_id`) |
-| `n_rgi6` | `integer` | Total number of RGI 6.0 outlines that overlap the RGI 7.0 outline (`rgi7_id`) |
-| `cluster_id` | `integer` | Arbitrary cluster identifier, which groups together all overlapping RGI 6.0 and RGI 7.0 outlines such that each cluster does not overlap any other cluster |
-```
+  ```{card}
+  | Column | Type | Description |
+  | -- | -- | -- |
+  | `rgi7_id` | string | RGI 6.0 outline |
+  | `rgi6_id` | string | RGI 7.0 outline |
+  | `overlap_area_km2` | number | Overlap area in km<sup>2</sup> |
+  | `rgi7_area_fraction` | number | Overlap area (`overlap_area_km2`) divided by the area of the RGI 7.0 outline (`rgi7_id`) |
+  | `rgi6_area_fraction` | number | Overlap area (`overlap_area_km2`) divided by the area of the RGI 60 outline (`rgi6_id`) |
+  | `n_rgi7` | integer | Total number of RGI 7.0 outlines that overlap the RGI 6.0 outline (`rgi6_id`) |
+  | `n_rgi6` | integer | Total number of RGI 6.0 outlines that overlap the RGI 7.0 outline (`rgi7_id`) |
+  | `cluster_id` | integer | Arbitrary cluster identifier, which groups together all overlapping RGI 6.0 and RGI 7.0 outlines such that each cluster does not overlap any other cluster |
+  ```
 
-For example, if an RGI 6 outline perfectly matches an RGI 7 outline, the overlap is a 1:1 relation (`n_rgi6`: 1, `n_rgi7`: 1) with 100% coverage (`rgi7_area_fraction`: 1, `rgi6_area_fraction`: 1). If an RGI 6 outline divided into two outlines (of equal area) in RGI 7, the two overlaps are part of a 1:2 relation (`n_rgi6`: 1, `n_rgi7`: 2) with 50% and 100% coverage (`rgi6_area_fraction`: 0.5, `rgi7_area_fraction`: 1). Often the relation between RGI7 and RGI6 is more complex, for example when an outline was remapped in RGI 7 and partially overlaps many in RGI 6.
+  For example, if an RGI 6 outline perfectly matches an RGI 7 outline, the overlap is a 1:1 relation (`n_rgi6`: 1, `n_rgi7`: 1) with 100% coverage (`rgi7_area_fraction`: 1, `rgi6_area_fraction`: 1). If an RGI 6 outline divided into two outlines (of equal area) in RGI 7, the two overlaps are part of a 1:2 relation (`n_rgi6`: 1, `n_rgi7`: 2) with 50% and 100% coverage (`rgi6_area_fraction`: 0.5, `rgi7_area_fraction`: 1). Often the relation between RGI7 and RGI6 is more complex, for example when an outline was remapped in RGI 7 and partially overlaps many in RGI 6.
 
 `RGI2000-v7.0-G-01_alaska-hypsometry.csv`
 : **Hypsometry** for each glacier, preceded by copies of the glacier's `rgi_id` and `area_km2`. The hypsometry data are given as a comma-separated series of elevation-band areas in the form of integer thousandths of the glacier's total area in km² (`area_km2`). The sum of the elevation-band area values is constrained to be 1000. This means that an elevation band's value divided by 10 represents the elevation band's area as a percentage of total glacier area. For example, a value of 500 for a particular elevation bands means that it contains 50% of the total glacier area. The elevation bands are all 50 m in height and their central elevations are listed in the file header record. Within each hypsometry file the elevation bands extend from the lowest glacierized elevation up to the highest glacierized elevation band of the corresponding first-order region.

--- a/docs/products/glacier_product.md
+++ b/docs/products/glacier_product.md
@@ -28,7 +28,22 @@ In the following, file contents are explained using RGI region 01 (Alaska) as ex
 : **Description of the columns** in the `submission_info.csv` file: full name, description, units, etc. The content of this file is displayed in [](subm-info) below.
 
 `RGI2000-v7.0-G-01_alaska-rgi6_links.csv`
-: A list of **overlapping outline pairs** between RGI 7.0 and RGI 6.0 describing 1:1, 1:n, n:1 or n:n relationships as well as the overlapping area between them. For example, a perfect match between an RGI 7.0 and RGI 6.0 outline results in a 1:1 relation with 100% area match in both. If a single RGI 6.0 outline was divided into two glaciers for RGI 7.0, a 2:1 relationship (a cluster) would result with two lines in the table with twice 50% area match in RGI 6.0 and twice 100% match in RGI 7.0. In more complex cases the matches are not always perfect and the relationships less straightforward, for example when an outline was remapped.
+: A list of **all overlaps** (greater than 200 m<sup>2</sup>) between pairs of RGI 7.0 and RGI 6.0 glacier outlines, described by the following columns:
+
+```{card}
+| Column | Type | Description |
+| -- | -- | -- |
+| `rgi7_id` | `string` | RGI 6.0 outline |
+| `rgi6_id` | `string` | RGI 7.0 outline |
+| `overlap_area_km2` | `number` | Overlap area in km<sup>2</sup> |
+| `rgi7_area_fraction` | `number` | Overlap area (`overlap_area_km2`) divided by the area of the RGI 7.0 outline (`rgi7_id`) |
+| `rgi6_area_fraction` | `number` | Overlap area (`overlap_area_km2`) divided by the area of the RGI 60 outline (`rgi6_id`) |
+| `n_rgi7` | `integer` | Total number of RGI 7.0 outlines that overlap the RGI 6.0 outline (`rgi6_id`) |
+| `n_rgi6` | `integer` | Total number of RGI 6.0 outlines that overlap the RGI 7.0 outline (`rgi7_id`) |
+| `cluster_id` | `integer` | Arbitrary cluster identifier, which groups together all overlapping RGI 6.0 and RGI 7.0 outlines such that each cluster does not overlap any other cluster |
+```
+
+For example, if an RGI 6 outline perfectly matches an RGI 7 outline, the overlap is a 1:1 relation (`n_rgi6`: 1, `n_rgi7`: 1) with 100% coverage (`rgi7_area_fraction`: 1, `rgi6_area_fraction`: 1). If an RGI 6 outline divided into two outlines (of equal area) in RGI 7, the two overlaps are part of a 1:2 relation (`n_rgi6`: 1, `n_rgi7`: 2) with 50% and 100% coverage (`rgi6_area_fraction`: 0.5, `rgi7_area_fraction`: 1). Often the relation between RGI7 and RGI6 is more complex, for example when an outline was remapped in RGI 7 and partially overlaps many in RGI 6.
 
 `RGI2000-v7.0-G-01_alaska-hypsometry.csv`
 : **Hypsometry** for each glacier, preceded by copies of the glacier's `rgi_id` and `area_km2`. The hypsometry data are given as a comma-separated series of elevation-band areas in the form of integer thousandths of the glacier's total area in km² (`area_km2`). The sum of the elevation-band area values is constrained to be 1000. This means that an elevation band's value divided by 10 represents the elevation band's area as a percentage of total glacier area. For example, a value of 500 for a particular elevation bands means that it contains 50% of the total glacier area. The elevation bands are all 50 m in height and their central elevations are listed in the file header record. Within each hypsometry file the elevation bands extend from the lowest glacierized elevation up to the highest glacierized elevation band of the corresponding first-order region.

--- a/docs/products/glacier_product.md
+++ b/docs/products/glacier_product.md
@@ -33,14 +33,16 @@ In the following, file contents are explained using RGI region 01 (Alaska) as ex
   ```{card}
   | Column | Type | Description |
   | -- | -- | -- |
-  | `rgi7_id` | string | RGI 6.0 outline |
-  | `rgi6_id` | string | RGI 7.0 outline |
+  | `rgi7_id` | string | RGI 6.0 outline identifier |
+  | `rgi6_id` | string | RGI 7.0 outline identifier |
+  | `rgi7_reg` | string | RGI 7.0 region identifier |
+  | `rgi6_reg` | string | RGI 6.0 region identifier |
   | `overlap_area_km2` | number | Overlap area in km<sup>2</sup> |
   | `rgi7_area_fraction` | number | Overlap area (`overlap_area_km2`) divided by the area of the RGI 7.0 outline (`rgi7_id`) |
   | `rgi6_area_fraction` | number | Overlap area (`overlap_area_km2`) divided by the area of the RGI 60 outline (`rgi6_id`) |
   | `n_rgi7` | integer | Total number of RGI 7.0 outlines that overlap the RGI 6.0 outline (`rgi6_id`) |
   | `n_rgi6` | integer | Total number of RGI 6.0 outlines that overlap the RGI 7.0 outline (`rgi7_id`) |
-  | `cluster_id` | integer | Arbitrary cluster identifier, which groups together all overlapping RGI 6.0 and RGI 7.0 outlines such that each cluster does not overlap any other cluster |
+  | `cluster_id` | integer | Arbitrary cluster identifier (unique globally), which groups together all overlapping RGI 6.0 and RGI 7.0 outlines such that each cluster does not overlap any other cluster |
   ```
 
   For example, if an RGI 6 outline perfectly matches an RGI 7 outline, the overlap is a 1:1 relation (`n_rgi6`: 1, `n_rgi7`: 1) with 100% coverage (`rgi7_area_fraction`: 1, `rgi6_area_fraction`: 1). If an RGI 6 outline divided into two outlines (of equal area) in RGI 7, the two overlaps are part of a 1:2 relation (`n_rgi6`: 1, `n_rgi7`: 2) with 50% and 100% coverage (`rgi6_area_fraction`: 0.5, `rgi7_area_fraction`: 1). Often the relation between RGI7 and RGI6 is more complex, for example when an outline was remapped in RGI 7 and partially overlaps many in RGI 6.


### PR DESCRIPTION
Updates the text and adds a table to describe the `_links.csv` files.
See #83.

p.s. @fmaussion I notice that you broke up the overlaps by region. If I recall correctly, glaciers from some regions in RGI 7.0 overlap those of other regions in RGI 6.0, and thus why I recommended the links be processed globally. Were the overlaps (and the corresponding `cluster_id`, `n_rgi6`, `n_rgi7`) computed globally and then split (how?) into region files? Is `cluster_id` globally unique?